### PR TITLE
Bitfinex trades API call with since-parameter

### DIFF
--- a/bitquant/api.py
+++ b/bitquant/api.py
@@ -72,6 +72,7 @@ class request(object):
 
 		cmd = {'bitfinex':{'btcusd':{'url':'https://api.bitfinex.com/v1',
 			   		     'trades':'trades/btcusd','limit':'limit_trades=',
+			   		     'since':'timestamp=',
 					     'quandl':'BCHARTS/BITFINEXUSD','bchart':'bitfinexUSD'},
 				   'ltcusd':{'url':'https://api.bitfinex.com/v1',
 					     'trades':'trades/ltcusd','limit':'limit_trades='}},

--- a/bitquant/tools.py
+++ b/bitquant/tools.py
@@ -39,7 +39,7 @@ def olhcv(trd, freq, exchange='', symbol='', label='left', tsmp_col='no'):
 		prc['timestamp'] = prc.index.astype(np.int64) // 10**9
 
 	#|Slice price data to cut off incomplete ends
-	#prc = prc[1:-1]
+	prc = prc[1:-1]
 	return prc
 
 #|Replace zeros in open, low, and high with the last close


### PR DESCRIPTION
Now allows to limit trades as

```
bq.request('bitfinex', 'btcusd', limit=5000, since=1427915051)
```
